### PR TITLE
Allow sheets to have holes in holes

### DIFF
--- a/python/packaide/packaide.py
+++ b/python/packaide/packaide.py
@@ -8,7 +8,7 @@ import svgelements
 from xml.dom import minidom
 
 from PackaideBindings import Point, Polygon, PolygonWithHoles, Sheet, State, Placement
-from PackaideBindings import pack_decreasing, sheet_add_holes
+from PackaideBindings import pack_decreasing, sheet_add_holes_with_holes
 
 # We want to preserve presentation and identification (e.g., id, name, class) attributes
 # when flattening the SVG elements and writing them into the output, so that the packed
@@ -252,8 +252,7 @@ def pack(sheet_svgs, shapes, offset = 1, tolerance = 1, partial_solution = False
     sheet = Sheet()
     _, holes = extract_polygons(svg_string, tolerance, offset)
     sheet.height, sheet.width = get_sheet_dimensions(svg_string)
-    holes = [hole.boundary for hole in holes]
-    sheet_add_holes(sheet, holes, state)
+    sheet_add_holes_with_holes(sheet, holes, state)
     sheets.append(sheet)
 
   # Run the packing algorithm

--- a/src/bindings.cpp
+++ b/src/bindings.cpp
@@ -69,13 +69,27 @@ packaide::PolygonWithHoles boost_polygon_with_holes_convert(const Polygon_with_h
 // ------------------------------------------------------
 //                    Helper functions
 
-// Given a sheet object and a list of polyons, add those 
+// Given a sheet object and a list of polygons, add those 
 // polygons as holes to the sheet
 void sheet_add_holes_bind(packaide::Sheet& sheet, boost::python::list polygons, packaide::State& state){
   std::vector<Polygon_with_holes_2> pgons;
   for(boost::python::ssize_t i=0; i<boost::python::len(polygons); i++){
-    auto hole = Polygon_with_holes_2(packaide_polygon_convert(boost::python::extract<packaide::Polygon>(polygons[i])));
+    auto python_polygon = boost::python::extract<packaide::Polygon>(polygons[i]);
+    auto packaide_polygon = packaide_polygon_convert(python_polygon);
+    auto hole = Polygon_with_holes_2(packaide_polygon);
     pgons.push_back(hole);
+  }
+  sheet.holes = pgons;
+}
+
+// Given a sheet object and a list of polygons with holes, add those 
+// polygons as holes to the sheet
+void sheet_add_holes_with_holes_bind(packaide::Sheet& sheet, boost::python::list polygons_with_holes, packaide::State& state){
+  std::vector<Polygon_with_holes_2> pgons;
+  for(boost::python::ssize_t i=0; i<boost::python::len(polygons_with_holes); i++){
+    auto python_polygon = boost::python::extract<packaide::PolygonWithHoles>(polygons_with_holes[i]);
+    auto packaide_polygon = packaide_polygon_with_holes_convert(python_polygon);
+    pgons.push_back(packaide_polygon);
   }
   sheet.holes = pgons;
 }
@@ -172,5 +186,6 @@ BOOST_PYTHON_MODULE(PackaideBindings) {
   class_<packaide::State>("State", init<>());
 
   def("sheet_add_holes", sheet_add_holes_bind);
+  def("sheet_add_holes_with_holes", sheet_add_holes_with_holes_bind);
   def("pack_decreasing", pack_decreasing_bind);
 }


### PR DESCRIPTION
This PR allows sheet's holes to have holes in them. Holes in the sheet describe the zones where packing is prohibited, with this PR one can have allowed zones inside prohibited zones. 

We can now invert the sheet's path and have the library pack only inside a specified zone. Inverting the sheet polygon is as simple as adding a rectangle as big as the viewBox followed by the polygon we want to use as the allowed zone.

### Sheet inverting example

allowed_zone.svg (in pink), the place we want to pack into
```svg
<svg viewBox="0 0 1000 1000">
	<path d="M100 600 L900 600 L 900 300 L 100 300 Z" fill="pink" stroke="black"/>
</svg>
```

inverted_allowed_zone.svg (in yellow), the svg to use as a sheet
```svg
<svg viewBox="0 0 1000 1000">
	<path d="M0 0 L 1000 0 L 1000 1000 L 0 1000 Z       M100 600 L900 600 L 900 300 L 100 300 Z" fill="yellow" stroke="black"/>
</svg>
```
<details>
<summary>Images</summary>

![allowed_sheet](https://github.com/user-attachments/assets/0a2b1d32-662f-4cfc-a2d8-5fb733273f96)

![inverted_allowed_sheet](https://github.com/user-attachments/assets/af8537b4-b9a3-442d-8b9f-a8db276a3e83)

</details>



This effectively solves issue #5 